### PR TITLE
Better gathering of Aragon DAOs based on token info

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -43,7 +43,6 @@
     "@datorama/akita": "^4.10.2",
     "antd": "^3.22.0",
     "apollo-boost": "^0.4.4",
-    "axios": "^0.19.0",
     "bignumber.js": "^9.0.0",
     "ethereum-blockies-base64": "^1.0.2",
     "graphql": "^14.5.3",
@@ -57,6 +56,7 @@
   },
   "devDependencies": {
     "@machinomy/hdwallet-provider": "^1.7.1",
+    "@types/fetch-mock": "^7.3.1",
     "@types/jest": "24.0.18",
     "@types/memoizee": "^0.4.2",
     "@types/node": "12.7.2",
@@ -69,6 +69,7 @@
     "@types/web3": "^1.0.19",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
+    "fetch-mock": "^7.3.9",
     "jest-marbles": "^2.5.0",
     "prettier": "^1.18.2",
     "react-scripts": "3.1.1",

--- a/web/package.json
+++ b/web/package.json
@@ -43,6 +43,7 @@
     "@datorama/akita": "^4.10.2",
     "antd": "^3.22.0",
     "apollo-boost": "^0.4.4",
+    "axios": "^0.19.0",
     "bignumber.js": "^9.0.0",
     "ethereum-blockies-base64": "^1.0.2",
     "graphql": "^14.5.3",
@@ -51,6 +52,7 @@
     "react-dom": "^16.9.0",
     "react-router-dom": "^5.0.1",
     "rxjs": "^6.3.3",
+    "underscore": "1.9.1",
     "web3": "^1.2.1"
   },
   "devDependencies": {
@@ -63,6 +65,7 @@
     "@types/react-router": "^5.0.3",
     "@types/react-router-dom": "^4.3.5",
     "@types/react-test-renderer": "^16.9.0",
+    "@types/underscore": "^1.9.3",
     "@types/web3": "^1.0.19",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",

--- a/web/src/abis/aragon-token.abi.json
+++ b/web/src/abis/aragon-token.abi.json
@@ -1,1 +1,295 @@
-[{"constant":true,"inputs":[],"name":"name","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_spender","type":"address"},{"name":"_amount","type":"uint256"}],"name":"approve","outputs":[{"name":"success","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"creationBlock","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"totalSupply","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_from","type":"address"},{"name":"_to","type":"address"},{"name":"_amount","type":"uint256"}],"name":"transferFrom","outputs":[{"name":"success","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"decimals","outputs":[{"name":"","type":"uint8"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_newController","type":"address"}],"name":"changeController","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[{"name":"_owner","type":"address"},{"name":"_blockNumber","type":"uint256"}],"name":"balanceOfAt","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"version","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_cloneTokenName","type":"string"},{"name":"_cloneDecimalUnits","type":"uint8"},{"name":"_cloneTokenSymbol","type":"string"},{"name":"_snapshotBlock","type":"uint256"},{"name":"_transfersEnabled","type":"bool"}],"name":"createCloneToken","outputs":[{"name":"","type":"address"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[{"name":"_owner","type":"address"}],"name":"balanceOf","outputs":[{"name":"balance","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"parentToken","outputs":[{"name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_owner","type":"address"},{"name":"_amount","type":"uint256"}],"name":"generateTokens","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"symbol","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"_blockNumber","type":"uint256"}],"name":"totalSupplyAt","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_to","type":"address"},{"name":"_amount","type":"uint256"}],"name":"transfer","outputs":[{"name":"success","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"transfersEnabled","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"parentSnapShotBlock","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_spender","type":"address"},{"name":"_amount","type":"uint256"},{"name":"_extraData","type":"bytes"}],"name":"approveAndCall","outputs":[{"name":"success","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"name":"_owner","type":"address"},{"name":"_amount","type":"uint256"}],"name":"destroyTokens","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[{"name":"_owner","type":"address"},{"name":"_spender","type":"address"}],"name":"allowance","outputs":[{"name":"remaining","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_token","type":"address"}],"name":"claimTokens","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"tokenFactory","outputs":[{"name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_transfersEnabled","type":"bool"}],"name":"enableTransfers","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"controller","outputs":[{"name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"inputs":[{"name":"_tokenFactory","type":"address"},{"name":"_parentToken","type":"address"},{"name":"_parentSnapShotBlock","type":"uint256"},{"name":"_tokenName","type":"string"},{"name":"_decimalUnits","type":"uint8"},{"name":"_tokenSymbol","type":"string"},{"name":"_transfersEnabled","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"constructor"},{"payable":true,"stateMutability":"payable","type":"fallback"},{"anonymous":false,"inputs":[{"indexed":true,"name":"_token","type":"address"},{"indexed":true,"name":"_controller","type":"address"},{"indexed":false,"name":"_amount","type":"uint256"}],"name":"ClaimedTokens","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"_from","type":"address"},{"indexed":true,"name":"_to","type":"address"},{"indexed":false,"name":"_amount","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"_cloneToken","type":"address"},{"indexed":false,"name":"_snapshotBlock","type":"uint256"}],"name":"NewCloneToken","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"_owner","type":"address"},{"indexed":true,"name":"_spender","type":"address"},{"indexed":false,"name":"_amount","type":"uint256"}],"name":"Approval","type":"event"}]
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "_spender", "type": "address" }, { "name": "_amount", "type": "uint256" }],
+    "name": "approve",
+    "outputs": [{ "name": "success", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "creationBlock",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_from", "type": "address" },
+      { "name": "_to", "type": "address" },
+      { "name": "_amount", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "name": "success", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "name": "", "type": "uint8" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "_newController", "type": "address" }],
+    "name": "changeController",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "_owner", "type": "address" }, { "name": "_blockNumber", "type": "uint256" }],
+    "name": "balanceOfAt",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "version",
+    "outputs": [{ "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_cloneTokenName", "type": "string" },
+      { "name": "_cloneDecimalUnits", "type": "uint8" },
+      { "name": "_cloneTokenSymbol", "type": "string" },
+      { "name": "_snapshotBlock", "type": "uint256" },
+      { "name": "_transfersEnabled", "type": "bool" }
+    ],
+    "name": "createCloneToken",
+    "outputs": [{ "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "_owner", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "name": "balance", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "parentToken",
+    "outputs": [{ "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "_owner", "type": "address" }, { "name": "_amount", "type": "uint256" }],
+    "name": "generateTokens",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "_blockNumber", "type": "uint256" }],
+    "name": "totalSupplyAt",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "_to", "type": "address" }, { "name": "_amount", "type": "uint256" }],
+    "name": "transfer",
+    "outputs": [{ "name": "success", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "transfersEnabled",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "parentSnapShotBlock",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_spender", "type": "address" },
+      { "name": "_amount", "type": "uint256" },
+      { "name": "_extraData", "type": "bytes" }
+    ],
+    "name": "approveAndCall",
+    "outputs": [{ "name": "success", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "_owner", "type": "address" }, { "name": "_amount", "type": "uint256" }],
+    "name": "destroyTokens",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "_owner", "type": "address" }, { "name": "_spender", "type": "address" }],
+    "name": "allowance",
+    "outputs": [{ "name": "remaining", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "_token", "type": "address" }],
+    "name": "claimTokens",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "tokenFactory",
+    "outputs": [{ "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "_transfersEnabled", "type": "bool" }],
+    "name": "enableTransfers",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "controller",
+    "outputs": [{ "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "name": "_tokenFactory", "type": "address" },
+      { "name": "_parentToken", "type": "address" },
+      { "name": "_parentSnapShotBlock", "type": "uint256" },
+      { "name": "_tokenName", "type": "string" },
+      { "name": "_decimalUnits", "type": "uint8" },
+      { "name": "_tokenSymbol", "type": "string" },
+      { "name": "_transfersEnabled", "type": "bool" }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  { "payable": true, "stateMutability": "payable", "type": "fallback" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "_token", "type": "address" },
+      { "indexed": true, "name": "_controller", "type": "address" },
+      { "indexed": false, "name": "_amount", "type": "uint256" }
+    ],
+    "name": "ClaimedTokens",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "_from", "type": "address" },
+      { "indexed": true, "name": "_to", "type": "address" },
+      { "indexed": false, "name": "_amount", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "_cloneToken", "type": "address" },
+      { "indexed": false, "name": "_snapshotBlock", "type": "uint256" }
+    ],
+    "name": "NewCloneToken",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "_owner", "type": "address" },
+      { "indexed": true, "name": "_spender", "type": "address" },
+      { "indexed": false, "name": "_amount", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  }
+]

--- a/web/src/services/daos/daos.service.ts
+++ b/web/src/services/daos/daos.service.ts
@@ -8,6 +8,7 @@ import { AragonService } from "./protocols/aragon.service";
 import { DaostackService } from "./protocols/daostack.service";
 import { BalanceService } from "../balance.service";
 import { Dao } from "../../model/dao";
+import { EtherscanService } from "../etherscan.service";
 
 export class DaosService {
   private readonly store: DaosStore;
@@ -17,7 +18,7 @@ export class DaosService {
   private readonly aragonService$: Observable<AragonService>;
   private readonly daostackService$: Observable<DaostackService>;
 
-  constructor(watchedAddresses$: Observable<string[]>, web3$: Observable<Web3>, account$: Observable<string>) {
+  constructor(watchedAddresses$: Observable<string[]>, web3$: Observable<Web3>, account$: Observable<string>, etherscanService: EtherscanService) {
     this.store = new DaosStore({
       daos: []
     });
@@ -25,7 +26,7 @@ export class DaosService {
     this.query = new DaosQuery(this.store);
     this.balanceService$ = web3$.pipe(map(web3 => new BalanceService(web3)));
     this.molochService$ = zip(web3$, this.balanceService$).pipe(map(p => new MolochService(p[0], p[1])));
-    this.aragonService$ = zip(web3$, this.balanceService$).pipe(map(p => new AragonService(p[0], p[1])));
+    this.aragonService$ = zip(web3$, this.balanceService$).pipe(map(p => new AragonService(p[0], p[1], etherscanService)));
     this.daostackService$ = this.balanceService$.pipe(map(bs => new DaostackService(bs)));
 
     zip(watchedAddresses$, account$)

--- a/web/src/services/daos/daos.service.ts
+++ b/web/src/services/daos/daos.service.ts
@@ -18,7 +18,12 @@ export class DaosService {
   private readonly aragonService$: Observable<AragonService>;
   private readonly daostackService$: Observable<DaostackService>;
 
-  constructor(watchedAddresses$: Observable<string[]>, web3$: Observable<Web3>, account$: Observable<string>, etherscanService: EtherscanService) {
+  constructor(
+    watchedAddresses$: Observable<string[]>,
+    web3$: Observable<Web3>,
+    account$: Observable<string>,
+    etherscanService: EtherscanService
+  ) {
     this.store = new DaosStore({
       daos: []
     });
@@ -26,7 +31,9 @@ export class DaosService {
     this.query = new DaosQuery(this.store);
     this.balanceService$ = web3$.pipe(map(web3 => new BalanceService(web3)));
     this.molochService$ = zip(web3$, this.balanceService$).pipe(map(p => new MolochService(p[0], p[1])));
-    this.aragonService$ = zip(web3$, this.balanceService$).pipe(map(p => new AragonService(p[0], p[1], etherscanService)));
+    this.aragonService$ = zip(web3$, this.balanceService$).pipe(
+      map(p => new AragonService(p[0], p[1], etherscanService))
+    );
     this.daostackService$ = this.balanceService$.pipe(map(bs => new DaostackService(bs)));
 
     zip(watchedAddresses$, account$)

--- a/web/src/services/daos/protocols/aragon.service.ts
+++ b/web/src/services/daos/protocols/aragon.service.ts
@@ -10,11 +10,7 @@ import { DaoType } from "../../../model/dao-type";
 import { Dao } from "../../../model/dao";
 import { IDaoService } from "../dao.service";
 import { EtherscanService } from "../../etherscan.service";
-
-async function hasMethod(web3: Web3, contractAddress: string, signature: string): Promise<boolean> {
-  const code = await web3.eth.getCode(contractAddress);
-  return code.indexOf(signature.slice(2, signature.length)) > 0;
-}
+import _ from "underscore";
 
 export class AragonService implements IDaoService {
   private readonly ensApollo: ApolloClient<unknown>;
@@ -73,69 +69,67 @@ export class AragonService implements IDaoService {
     throw new Error("Method not implemented.");
   }
 
-  public async getDaosByAccount(address: string): Promise<Dao[]> {
-    const tokenContracts = await this.etherscanService.tokenContractsByAccount(address);
-    const aragonKernels = [];
-    for await (const contractAddress of tokenContracts) {
-      const tokenContract = new this.web3.eth.Contract(aragonTokenABI, contractAddress);
-      const signature = tokenContract.methods.controller().encodeABI();
-      const isAragonToken = await hasMethod(this.web3, contractAddress, signature);
-      if (isAragonToken) {
-        try {
-          const controllerAddress = await tokenContract.methods.controller().call();
-          const controller = new this.web3.eth.Contract(aragonTokenControllerABI, controllerAddress);
-          const kernel: string = await controller.methods.kernel().call();
-          const kernelContract = new this.web3.eth.Contract(aragonKernelABI, kernel);
-          const vaultAddress = await kernelContract.methods
-            .apps(
-              "0xd6f028ca0e8edb4a8c9757ca4fdccab25fa1e0317da1188108f7d2dee14902fb",
-              "0x7e852e0fcfce6551c13800f1e7476f982525c2b5277ba14b24339c68416336d1"
-            )
-            .call();
-          const balance = await this.balanceService.balance(vaultAddress);
-          const a = await this.ensApollo.query({
-            query: gql`
-              query {
-                  domains(where: {resolvedAddress: "${kernel.toLowerCase()}"}) {
-                      name
-                      labelhash
-                      parent {
-                          id
-                      }
-                  }
-              }
-          `
-          });
-          const labelHash = a.data.domains[0].labelhash;
-          const parentId = a.data.domains[0].parent.id.toLowerCase();
-          const name = await this.fetchName(parentId, labelHash);
-          const hiveNames = await this.fetchAllNames();
-          const hiveEntity = hiveNames.find((t: any) => t.address.toLowerCase() === kernel.toLowerCase());
-          const hiveName = hiveEntity ? hiveEntity.name : null;
-          const graphqlName = name ? `${name}.aragonid.eth` : null;
+  public async daoByToken(tokenAddress: string, account: string): Promise<Dao | undefined> {
+    try {
+      const tokenContract = new this.web3.eth.Contract(aragonTokenABI, tokenAddress);
+      const controllerAddress = await tokenContract.methods.controller().call();
+      const controller = new this.web3.eth.Contract(aragonTokenControllerABI, controllerAddress);
+      const kernel: string = await controller.methods.kernel().call();
+      const kernelContract = new this.web3.eth.Contract(aragonKernelABI, kernel);
+      const vaultAddress = await kernelContract.methods
+        .apps(
+          "0xd6f028ca0e8edb4a8c9757ca4fdccab25fa1e0317da1188108f7d2dee14902fb",
+          "0x7e852e0fcfce6551c13800f1e7476f982525c2b5277ba14b24339c68416336d1"
+        )
+        .call();
+      const balance = await this.balanceService.balance(vaultAddress);
+      const a = await this.ensApollo.query({
+        query: gql`
+            query {
+                domains(where: {resolvedAddress: "${kernel.toLowerCase()}"}) {
+                    name
+                    labelhash
+                    parent {
+                        id
+                    }
+                }
+            }
+        `
+      });
+      const labelHash = a.data.domains[0].labelhash;
+      const parentId = a.data.domains[0].parent.id.toLowerCase();
+      const name = await this.fetchName(parentId, labelHash);
+      const hiveNames = await this.fetchAllNames();
+      const hiveEntity = hiveNames.find((t: any) => t.address.toLowerCase() === kernel.toLowerCase());
+      const hiveName = hiveEntity ? hiveEntity.name : null;
+      const graphqlName = name ? `${name}.aragonid.eth` : null;
 
-          const decimals = Number(await tokenContract.methods.decimals().call());
-          const shareBalance = new BigNumber(await tokenContract.methods.balanceOf(address).call())
-            .dividedBy(10 ** decimals)
-            .toNumber();
-          const totalSupply = new BigNumber(await tokenContract.methods.totalSupply().call())
-            .dividedBy(10 ** decimals)
-            .toNumber();
-          const dao: Dao = {
-            address: kernel.toLowerCase(),
-            name: graphqlName || hiveName || kernel,
-            kind: DaoType.ARAGON,
-            shareBalance,
-            totalSupply,
-            balance,
-            usdBalance: balance.reduce((acc, cur) => acc + cur.usdValue, 0)
-          };
-          aragonKernels.push(dao);
-        } catch (ex) {
-          console.log("Failed to parse token: " + contractAddress);
-        }
-      }
+      const decimals = Number(await tokenContract.methods.decimals().call());
+      const shareBalance = new BigNumber(await tokenContract.methods.balanceOf(account).call())
+        .dividedBy(10 ** decimals)
+        .toNumber();
+      const totalSupply = new BigNumber(await tokenContract.methods.totalSupply().call())
+        .dividedBy(10 ** decimals)
+        .toNumber();
+      const dao: Dao = {
+        address: kernel.toLowerCase(),
+        name: graphqlName || hiveName || kernel,
+        kind: DaoType.ARAGON,
+        shareBalance,
+        totalSupply,
+        balance,
+        usdBalance: balance.reduce((acc, cur) => acc + cur.usdValue, 0)
+      };
+      return dao;
+    } catch (ex) {
+      console.warn(`Token is not of Aragon DAO, tokenAddress=${tokenAddress}`);
+      return undefined;
     }
-    return aragonKernels;
+  }
+
+  public async getDaosByAccount(account: string): Promise<Dao[]> {
+    const tokenContracts = await this.etherscanService.tokenContractsByAccount(account);
+    const daos = await Promise.all(tokenContracts.map(tokenAddress => this.daoByToken(tokenAddress, account)));
+    return _.compact(daos);
   }
 }

--- a/web/src/services/etherscan.service.test.ts
+++ b/web/src/services/etherscan.service.test.ts
@@ -1,0 +1,80 @@
+import { API_ENDPOINT, EtherscanService } from "./etherscan.service";
+import fetchMock from "fetch-mock";
+
+describe("constructor", () => {
+  it("set default api endpoint", () => {
+    const service = new EtherscanService();
+    expect(service.apiEndpoint).toEqual(API_ENDPOINT);
+  });
+
+  it("set api endpoint", () => {
+    const endpoint = "foo";
+    const service = new EtherscanService(endpoint);
+    expect(service.apiEndpoint).toEqual(endpoint);
+  });
+});
+
+describe("#tokenContractsByAccount", () => {
+  const ACCOUNT = "0x421E56cA6E4B03350188CEc58d053B427245665d";
+  const TOKEN_ADDRESS = "0x42d6622dece394b54999fbd73d108123806f6a18";
+
+  it("fetch etherscan", async () => {
+    const service = new EtherscanService();
+    const endpoint = service.tokenContractsByAccountUrl(ACCOUNT);
+    fetchMock.mock(endpoint, {
+      status: 200,
+      body: {
+        status: "1",
+        message: "OK",
+        result: [
+          {
+            blockNumber: "8542033",
+            timeStamp: "1568387546",
+            hash: "0xa2acc767ee7b547a28d0f8d15d086bd1598a4f587117ce238fc9d49aa9d6b3bb",
+            nonce: "2",
+            blockHash: "0x251ceaf2cfe9705a02cdc94f09b312d1a8738c5c8c3690a322d3de14dc03d357",
+            from: "0x9000a8abe4828a7b801c0d46179a43815c37611a",
+            contractAddress: TOKEN_ADDRESS,
+            to: "0x421e56ca6e4b03350188cec58d053b427245665d",
+            value: "300000000000000000000000",
+            tokenName: "SPANK",
+            tokenSymbol: "SPANK",
+            tokenDecimal: "18",
+            transactionIndex: "81",
+            gas: "77392",
+            gasPrice: "20000000000",
+            gasUsed: "51659",
+            cumulativeGasUsed: "4395626",
+            input: "deprecated",
+            confirmations: "101093"
+          },
+          {
+            blockNumber: "8559500",
+            timeStamp: "1568623606",
+            hash: "0xaece13d8ba8e776da0fb08d4a5d0c0757bf9af1fda25d2f7558a42be17dbc12c",
+            nonce: "7",
+            blockHash: "0x3197b30d4490463fa540ece876e72af7866a79a7e40dea1e10d70e6af1cb1c03",
+            from: "0x421e56ca6e4b03350188cec58d053b427245665d",
+            contractAddress: "0x42d6622dece394b54999fbd73d108123806f6a18",
+            to: "0xbac675c310721717cd4a37f6cbea1f081b1c2a07",
+            value: "100000000000000000000000",
+            tokenName: "SPANK",
+            tokenSymbol: "SPANK",
+            tokenDecimal: "18",
+            transactionIndex: "123",
+            gas: "54988",
+            gasPrice: "22000000000",
+            gasUsed: "51659",
+            cumulativeGasUsed: "5883445",
+            input: "deprecated",
+            confirmations: "83626"
+          }
+        ]
+      }
+    });
+    const tokens = await service.tokenContractsByAccount("0x421E56cA6E4B03350188CEc58d053B427245665d");
+    expect(tokens.length).toEqual(1);
+    expect(tokens).toEqual([TOKEN_ADDRESS]);
+    fetchMock.restore();
+  });
+});

--- a/web/src/services/etherscan.service.ts
+++ b/web/src/services/etherscan.service.ts
@@ -1,0 +1,31 @@
+import _ from "underscore";
+
+export interface EtherscanTokenTxResponse {
+  status: string;
+  message: string;
+  result: Array<{ contractAddress: string }>;
+}
+
+export const API_ENDPOINT = "https://api.etherscan.io/api";
+
+export class EtherscanService {
+  constructor(readonly apiEndpoint: string = API_ENDPOINT) {}
+
+  tokenContractsByAccountUrl(account: string): string {
+    const endpoint = new URL(this.apiEndpoint);
+    endpoint.searchParams.set("module", "account");
+    endpoint.searchParams.set("action", "tokentx");
+    endpoint.searchParams.set("address", account);
+    endpoint.searchParams.set("startblock", "0");
+    endpoint.searchParams.set("endblock", "999999999");
+    endpoint.searchParams.set("sort", "asc");
+    return endpoint.toString();
+  }
+
+  async tokenContractsByAccount(account: string): Promise<string[]> {
+    const endpoint = this.tokenContractsByAccountUrl(account);
+    const response: Response = await fetch(endpoint);
+    const data = (await response.json()) as EtherscanTokenTxResponse;
+    return _.uniq<string, string>(data.result.map((t: any) => t.contractAddress));
+  }
+}

--- a/web/src/services/services.ts
+++ b/web/src/services/services.ts
@@ -5,6 +5,7 @@ import { SettingsService } from "./settings/settings.service";
 import { DaosService } from "./daos/daos.service";
 import { map } from "rxjs/operators";
 import { ProposalsService } from "./proposals/proposals.service";
+import { EtherscanService } from "./etherscan.service";
 
 export class Services {
   @memoize()
@@ -32,7 +33,13 @@ export class Services {
     const watchedAddresses$ = this.settings.query.loadedWatchedAddresses$;
     const web3$ = this.blockchain.ready$.pipe(map(p => p.web3));
     const account$ = this.blockchain.ready$.pipe(map(p => p.address));
-    return new DaosService(watchedAddresses$, web3$, account$);
+    const etherscan = this.etherscanService;
+    return new DaosService(watchedAddresses$, web3$, account$, etherscan);
+  }
+
+  @memoize()
+  get etherscanService() {
+    return new EtherscanService();
   }
 
   @memoize()

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1533,6 +1533,11 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
+"@types/fetch-mock@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@types/fetch-mock/-/fetch-mock-7.3.1.tgz#df7421e8bcb351b430bfbfa5c52bb353826ac94f"
+  integrity sha512-2U4vZWHNbsbK7TRmizgr/pbKe0FKopcxu+hNDtIBDiM1wvrKRItybaYj7VQ6w/hZJStU/JxRiNi5ww4YDEvKbA==
+
 "@types/history@*":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.3.tgz#856c99cdc1551d22c22b18b5402719affec9839a"
@@ -2682,14 +2687,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
-  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
-  dependencies:
-    follow-redirects "1.5.10"
-    is-buffer "^2.0.2"
-
 axobject-query@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.0.2.tgz#ea187abe5b9002b377f925d8bf7d1c561adf38f9"
@@ -3207,6 +3204,15 @@ babel-plugin-transform-strict-mode@^6.24.1:
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
+
+babel-polyfill@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  integrity sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
 
 babel-preset-env@^1.7.0:
   version "1.7.0"
@@ -4668,7 +4674,7 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.4.0, core-js@^2.5.0:
+core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
@@ -5128,13 +5134,6 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@=3.1.0, debug@~3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
 debug@^3.1.0, debug@^3.2.5, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
@@ -5148,6 +5147,13 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@~4.1.0:
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
+
+debug@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
 
 decamelize@^1.1.1, decamelize@^1.2.0:
   version "1.2.0"
@@ -6832,6 +6838,17 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
+fetch-mock@^7.3.9:
+  version "7.3.9"
+  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-7.3.9.tgz#a80fd2a1728f72e0634ef7a9734bc61200096487"
+  integrity sha512-PgsTbiQBNapFz2P2UwDl3gowK3nZqfV4HdyDZ1dI4eTGGH9MLAeBglIPbyDbbNQoGYBOfla6/9uaiq7az2z4Aw==
+  dependencies:
+    babel-polyfill "^6.26.0"
+    core-js "^2.6.9"
+    glob-to-regexp "^0.4.0"
+    path-to-regexp "^2.2.1"
+    whatwg-url "^6.5.0"
+
 fetch-ponyfill@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz#ae3ce5f732c645eab87e4ae8793414709b239893"
@@ -7005,13 +7022,6 @@ fnv1a@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fnv1a/-/fnv1a-1.0.1.tgz#915e2d6d023c43d5224ad9f6d2a3c4156f5712f5"
   integrity sha1-kV4tbQI8Q9UiStn20qPEFW9XEvU=
-
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
 
 follow-redirects@^1.0.0:
   version "1.7.0"
@@ -7330,6 +7340,11 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
+
+glob-to-regexp@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
+  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
 glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.4:
   version "7.1.4"
@@ -8816,7 +8831,7 @@ is-buffer@^1.0.2, is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-buffer@^2.0.2, is-buffer@^2.0.3:
+is-buffer@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
   integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
@@ -12807,6 +12822,11 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
+path-to-regexp@^2.2.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
+  integrity sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -15079,6 +15099,11 @@ regenerator-runtime@0.13.3, regenerator-runtime@^0.13.2:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
+regenerator-runtime@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+  integrity sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"
@@ -17991,7 +18016,7 @@ whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
 
-whatwg-url@^6.4.1:
+whatwg-url@^6.4.1, whatwg-url@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
   integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1666,6 +1666,11 @@
   resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.9.2.tgz#2c4f7743287218f5c2d9a83db3806672aa48530d"
   integrity sha512-KgOKTAD+9X+qvZnB5S1+onqKc4E+PZ+T6CM/NA5ohRPLHJXb+yCJMVf8pWOnvuBuKFNUAJW8N97IA6lba6mZGg==
 
+"@types/underscore@^1.9.3":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.9.3.tgz#d7d9dc5a5ff76fa3d001b29bc7cc95ab0ccfe85e"
+  integrity sha512-SwbHKB2DPIDlvYqtK5O+0LFtZAyrUSw4c0q+HWwmH1Ve3KMQ0/5PlV3RX97+3dP7yMrnNQ8/bCWWvQpPl03Mug==
+
 "@types/web3@^1.0.19":
   version "1.0.19"
   resolved "https://registry.yarnpkg.com/@types/web3/-/web3-1.0.19.tgz#46b85d91d398ded9ab7c85a5dd57cb33ac558924"
@@ -2676,6 +2681,14 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+
+axios@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
+  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+  dependencies:
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
 
 axobject-query@^2.0.2:
   version "2.0.2"
@@ -5115,6 +5128,13 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
+debug@=3.1.0, debug@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@^3.1.0, debug@^3.2.5, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
@@ -5128,13 +5148,6 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@~4.1.0:
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
-
-debug@~3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
 
 decamelize@^1.1.1, decamelize@^1.2.0:
   version "1.2.0"
@@ -6993,6 +7006,13 @@ fnv1a@^1.0.1:
   resolved "https://registry.yarnpkg.com/fnv1a/-/fnv1a-1.0.1.tgz#915e2d6d023c43d5224ad9f6d2a3c4156f5712f5"
   integrity sha1-kV4tbQI8Q9UiStn20qPEFW9XEvU=
 
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
+
 follow-redirects@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
@@ -8796,7 +8816,7 @@ is-buffer@^1.0.2, is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-buffer@^2.0.3:
+is-buffer@^2.0.2, is-buffer@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
   integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==


### PR DESCRIPTION
Fix #1 through consistently handling DAO token contracts. Do not rely on `token.controller()` heuristic anymore.

By the way, it makes loading Aragon DAOs faster by about 40% (from ~23s to ~13s).